### PR TITLE
61 copy input files v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.9]
+## [0.4.0]
+
+### Changed
+
+- **BREAKING**: Input files are now copied to `inputs/` subfolder instead of job root
+  - Dependency outputs are copied to `{job}/inputs/` folder
+  - Workflow `input_files/` contents are copied to first job's `inputs/` folder
+  - Scripts should read from `./inputs/` and write to `./outputs/`
 
 ### Added
 
-- Input files feature: workflows can now include an `input_files/` folder at the root, whose contents are automatically copied to the first job before execution
+- Input files feature: workflows can now include an `input_files/` folder at the root, whose contents are automatically copied to the first job's `inputs/` folder before execution
 
 ## [0.3.8]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "job_config"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "silva"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "arboard",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["job_config", "silva"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.9"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 authors = ["Qin Wan <qw@chiral.one>"]


### PR DESCRIPTION
Breaking change to standardize input/output folder conventions for job execution.

  Changes (v0.4.0):

  - BREAKING: Input files now use inputs/ subfolder convention
    - Dependency outputs are copied to {job}/inputs/ folder
    - Workflow input_files/ contents copied to first job's inputs/ folder
    - Scripts should read from ./inputs/ and write to ./outputs/
    - New Feature: Workflows can include an input_files/ folder at root
    - Contents automatically copied to first job's inputs/ before execution

  Test Plan

  - Create workflow with input_files/ folder and verify contents copied to first job's inputs/
  - Run multi-job workflow and verify dependency outputs copied to inputs/ subfolder
  - Verify scripts can read from ./inputs/ and write to ./outputs/
  - Test backward compatibility with existing workflows (may need migration)
