### PR TITLE
feat: move completed jobs to @complete/ (#71)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "job_config"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "silva"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arboard",
  "bollard",

--- a/silva/src/headless.rs
+++ b/silva/src/headless.rs
@@ -195,7 +195,19 @@ pub async fn run_workflow(workflow_path: &Path) -> Result<(), String> {
                         )
                         .await
                     {
-                        Ok(_container_id) => {}
+                        Ok(_container_id) => {
+                            // Move completed job to @complete/ to prevent cross-node path access
+                            if let Err(e) = move_job_to_complete(
+                                &temp_workflow_path_clone,
+                                &job.name,
+                            ) {
+                                let log_line = LogLine::new(
+                                    LogSource::Stderr,
+                                    format!("Warning: Failed to move '{}' to @complete: {e}", job.name),
+                                );
+                                let _ = tx.send((idx, JobStatus::Running, log_line)).await;
+                            }
+                        }
                         Err(e) => {
                             let log_line = LogLine::new(
                                 LogSource::Stderr,
@@ -421,7 +433,13 @@ fn copy_input_files_from_dependencies(
             continue;
         }
 
-        let dep_outputs_dir = workflow_path.join(dep_job_name).join("outputs");
+        // Look in @complete/ first (job already finished), fall back to original location
+        let complete_outputs_dir = workflow_path.join("@complete").join(dep_job_name).join("outputs");
+        let dep_outputs_dir = if complete_outputs_dir.exists() {
+            complete_outputs_dir
+        } else {
+            workflow_path.join(dep_job_name).join("outputs")
+        };
         if !dep_outputs_dir.exists() {
             println!("No outputs found for dependency '{dep_job_name}', skipping");
             continue;
@@ -518,6 +536,29 @@ fn create_temp_workflow_folder(source_path: &Path) -> std::io::Result<TempDir> {
         .map_err(|e| std::io::Error::other(format!("copy folder error {e}")))?;
 
     Ok(temp_dir)
+}
+
+/// Moves a completed job folder to `@complete/` to prevent cross-node path access.
+///
+/// After a job finishes, its folder is moved from the temp workflow root into
+/// `@complete/{job_name}/`. This ensures that subsequent jobs cannot use relative
+/// paths (e.g., `../01-data-prep/`) to access sibling node folders directly,
+/// forcing them to use the proper `inputs/` contract.
+fn move_job_to_complete(workflow_path: &Path, job_name: &str) -> Result<(), String> {
+    use std::fs;
+
+    let source = workflow_path.join(job_name);
+    let complete_dir = workflow_path.join("@complete");
+    let dest = complete_dir.join(job_name);
+
+    fs::create_dir_all(&complete_dir)
+        .map_err(|e| format!("Failed to create @complete directory: {e}"))?;
+
+    fs::rename(&source, &dest)
+        .map_err(|e| format!("Failed to move '{job_name}' to @complete: {e}"))?;
+
+    println!("[{job_name}] Moved to @complete/");
+    Ok(())
 }
 
 /// Copies files from the workflow's `input_files/` folder to all jobs without dependencies.

--- a/silva/tests/fixtures/workflow-complete/cross-node-cheat/.chiral/workflow.toml
+++ b/silva/tests/fixtures/workflow-complete/cross-node-cheat/.chiral/workflow.toml
@@ -1,0 +1,5 @@
+name = "cross-node-cheat"
+description = "Test that cross-node path access fails after move"
+
+[dependencies]
+02-consume = ["01-produce"]

--- a/silva/tests/fixtures/workflow-complete/cross-node-cheat/01-produce/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/cross-node-cheat/01-produce/.chiral/job.toml
@@ -1,0 +1,9 @@
+name = "Produce"
+description = "Produces a result file"
+outputs = ["result.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/cross-node-cheat/01-produce/run.sh
+++ b/silva/tests/fixtures/workflow-complete/cross-node-cheat/01-produce/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "secret data" > result.txt

--- a/silva/tests/fixtures/workflow-complete/cross-node-cheat/02-consume/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/cross-node-cheat/02-consume/.chiral/job.toml
@@ -1,0 +1,10 @@
+name = "Consume"
+description = "Tries to cheat with cross-node path"
+inputs = ["result.txt"]
+outputs = ["stolen.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/cross-node-cheat/02-consume/run.sh
+++ b/silva/tests/fixtures/workflow-complete/cross-node-cheat/02-consume/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+# This should FAIL because 01-produce has been moved to @complete/
+cp ../01-produce/outputs/result.txt stolen.txt

--- a/silva/tests/fixtures/workflow-complete/failed-job/.chiral/workflow.toml
+++ b/silva/tests/fixtures/workflow-complete/failed-job/.chiral/workflow.toml
@@ -1,0 +1,5 @@
+name = "failed-job"
+description = "Test that failed jobs are not moved to @complete"
+
+[dependencies]
+02-consume = ["01-produce"]

--- a/silva/tests/fixtures/workflow-complete/failed-job/01-produce/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/failed-job/01-produce/.chiral/job.toml
@@ -1,0 +1,9 @@
+name = "Produce"
+description = "This job fails"
+outputs = ["result.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/failed-job/01-produce/run.sh
+++ b/silva/tests/fixtures/workflow-complete/failed-job/01-produce/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "about to fail"
+exit 1

--- a/silva/tests/fixtures/workflow-complete/failed-job/02-consume/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/failed-job/02-consume/.chiral/job.toml
@@ -1,0 +1,9 @@
+name = "Consume"
+description = "Should never run"
+inputs = ["result.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/failed-job/02-consume/run.sh
+++ b/silva/tests/fixtures/workflow-complete/failed-job/02-consume/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "should not reach here"

--- a/silva/tests/fixtures/workflow-complete/inputs-contract/.chiral/workflow.toml
+++ b/silva/tests/fixtures/workflow-complete/inputs-contract/.chiral/workflow.toml
@@ -1,0 +1,5 @@
+name = "inputs-contract"
+description = "Test that the inputs/ contract still works after move"
+
+[dependencies]
+02-consume = ["01-produce"]

--- a/silva/tests/fixtures/workflow-complete/inputs-contract/01-produce/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/inputs-contract/01-produce/.chiral/job.toml
@@ -1,0 +1,9 @@
+name = "Produce"
+description = "Produces output files"
+outputs = ["data.csv", "metadata.json"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/inputs-contract/01-produce/run.sh
+++ b/silva/tests/fixtures/workflow-complete/inputs-contract/01-produce/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "col1,col2" > data.csv
+echo '{"rows": 1}' > metadata.json

--- a/silva/tests/fixtures/workflow-complete/inputs-contract/02-consume/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/inputs-contract/02-consume/.chiral/job.toml
@@ -1,0 +1,10 @@
+name = "Consume"
+description = "Reads from inputs using the proper contract"
+inputs = ["data.csv", "metadata.json"]
+outputs = ["report.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/inputs-contract/02-consume/run.sh
+++ b/silva/tests/fixtures/workflow-complete/inputs-contract/02-consume/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+# Proper usage: read from inputs/ directory
+cat inputs/data.csv > report.txt
+cat inputs/metadata.json >> report.txt
+echo "report complete" >> report.txt

--- a/silva/tests/fixtures/workflow-complete/three-node-chain/.chiral/workflow.toml
+++ b/silva/tests/fixtures/workflow-complete/three-node-chain/.chiral/workflow.toml
@@ -1,0 +1,6 @@
+name = "three-node-chain"
+description = "Test that all nodes in a chain are moved to @complete"
+
+[dependencies]
+02-consume = ["01-produce"]
+03-final = ["02-consume"]

--- a/silva/tests/fixtures/workflow-complete/three-node-chain/01-produce/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/three-node-chain/01-produce/.chiral/job.toml
@@ -1,0 +1,9 @@
+name = "Produce"
+description = "First node"
+outputs = ["step1.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/three-node-chain/01-produce/run.sh
+++ b/silva/tests/fixtures/workflow-complete/three-node-chain/01-produce/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "step1" > step1.txt

--- a/silva/tests/fixtures/workflow-complete/three-node-chain/02-consume/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/three-node-chain/02-consume/.chiral/job.toml
@@ -1,0 +1,10 @@
+name = "Consume"
+description = "Middle node"
+inputs = ["step1.txt"]
+outputs = ["step2.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/three-node-chain/02-consume/run.sh
+++ b/silva/tests/fixtures/workflow-complete/three-node-chain/02-consume/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat inputs/step1.txt > step2.txt
+echo "step2" >> step2.txt

--- a/silva/tests/fixtures/workflow-complete/three-node-chain/03-final/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/three-node-chain/03-final/.chiral/job.toml
@@ -1,0 +1,10 @@
+name = "Final"
+description = "Last node"
+inputs = ["step2.txt"]
+outputs = ["final.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/three-node-chain/03-final/run.sh
+++ b/silva/tests/fixtures/workflow-complete/three-node-chain/03-final/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat inputs/step2.txt > final.txt
+echo "done" >> final.txt

--- a/silva/tests/fixtures/workflow-complete/two-node-basic/.chiral/workflow.toml
+++ b/silva/tests/fixtures/workflow-complete/two-node-basic/.chiral/workflow.toml
@@ -1,0 +1,5 @@
+name = "two-node-basic"
+description = "Test that completed jobs are moved to @complete"
+
+[dependencies]
+02-consume = ["01-produce"]

--- a/silva/tests/fixtures/workflow-complete/two-node-basic/01-produce/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/two-node-basic/01-produce/.chiral/job.toml
@@ -1,0 +1,9 @@
+name = "Produce"
+description = "Produces a result file"
+outputs = ["result.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/two-node-basic/01-produce/run.sh
+++ b/silva/tests/fixtures/workflow-complete/two-node-basic/01-produce/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "hello from node 01" > result.txt

--- a/silva/tests/fixtures/workflow-complete/two-node-basic/02-consume/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/two-node-basic/02-consume/.chiral/job.toml
@@ -1,0 +1,10 @@
+name = "Consume"
+description = "Reads from inputs"
+inputs = ["result.txt"]
+outputs = ["done.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/two-node-basic/02-consume/run.sh
+++ b/silva/tests/fixtures/workflow-complete/two-node-basic/02-consume/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cat inputs/result.txt > done.txt

--- a/silva/tests/integration_complete.rs
+++ b/silva/tests/integration_complete.rs
@@ -1,0 +1,237 @@
+//! Integration tests for the @complete job isolation feature.
+//!
+//! These tests run silva headless against real workflow fixtures with Docker containers
+//! to verify that completed jobs are moved to @complete/ and cross-node path access is blocked.
+//!
+//! Requirements:
+//! - Docker must be running
+//! - alpine:latest image should be available (will be pulled if not)
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Returns the path to the silva binary built by cargo
+fn silva_bin() -> PathBuf {
+    // cargo test builds the binary in the same target directory
+    let mut path = std::env::current_exe()
+        .expect("Failed to get current exe path")
+        .parent()
+        .expect("Failed to get parent dir")
+        .parent()
+        .expect("Failed to get target dir")
+        .to_path_buf();
+    path.push("silva");
+    path
+}
+
+/// Returns the path to a test fixture workflow
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/workflow-complete")
+        .join(name)
+}
+
+/// Runs silva on a workflow fixture and returns (success, stdout, temp_folder_path)
+fn run_silva(fixture_name: &str) -> (bool, String, Option<PathBuf>) {
+    let fixture = fixture_path(fixture_name);
+    assert!(fixture.exists(), "Fixture not found: {}", fixture.display());
+
+    let output = Command::new(silva_bin())
+        .arg(&fixture)
+        .output()
+        .expect("Failed to run silva binary");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    // Print output for debugging on failure
+    if !output.status.success() {
+        eprintln!("=== STDOUT ===\n{stdout}");
+        eprintln!("=== STDERR ===\n{stderr}");
+    }
+
+    // Extract temp folder path from output
+    // Silva prints either "Output folder: /tmp/silva-..." or "Working folder: /tmp/silva-..."
+    let temp_path = stdout
+        .lines()
+        .chain(stderr.lines())
+        .find_map(|line| {
+            let line = line.trim();
+            if line.starts_with("Output folder:") || line.starts_with("Working folder:") {
+                line.split(':').nth(1).map(|p| PathBuf::from(p.trim()))
+            } else {
+                None
+            }
+        });
+
+    (output.status.success(), stdout, temp_path)
+}
+
+/// Check if Docker is available, skip test if not
+fn require_docker() {
+    let output = Command::new("docker").arg("info").output();
+    match output {
+        Ok(o) if o.status.success() => {}
+        _ => {
+            eprintln!("Docker is not available, skipping integration test");
+            std::process::exit(0);
+        }
+    }
+}
+
+#[test]
+fn test_completed_job_moved_to_complete() {
+    require_docker();
+
+    let (success, _stdout, temp_path) = run_silva("two-node-basic");
+    assert!(success, "Workflow should succeed");
+
+    let temp = temp_path.expect("Should have temp folder path");
+
+    // 01-produce should be in @complete/, not in root
+    assert!(
+        !temp.join("01-produce").exists(),
+        "01-produce should not exist in root after completion"
+    );
+    assert!(
+        temp.join("@complete/01-produce").exists(),
+        "01-produce should be in @complete/"
+    );
+    assert!(
+        temp.join("@complete/01-produce/outputs/result.txt").exists(),
+        "01-produce outputs should be preserved in @complete/"
+    );
+
+    // 02-consume should also be in @complete/ (it's the last job)
+    assert!(
+        temp.join("@complete/02-consume").exists(),
+        "02-consume should be in @complete/"
+    );
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn test_cross_node_path_access_fails() {
+    require_docker();
+
+    let (success, _stdout, temp_path) = run_silva("cross-node-cheat");
+    assert!(
+        !success,
+        "Workflow should fail because cross-node cp should error"
+    );
+
+    let temp = temp_path.expect("Should have temp folder path");
+
+    // 01-produce completed successfully, so it should be in @complete/
+    assert!(
+        temp.join("@complete/01-produce").exists(),
+        "01-produce should be in @complete/ (it succeeded before 02 ran)"
+    );
+
+    // 02-consume failed, so it should NOT be in @complete/
+    assert!(
+        !temp.join("@complete/02-consume").exists(),
+        "02-consume should not be in @complete/ (it failed)"
+    );
+    assert!(
+        temp.join("02-consume").exists(),
+        "02-consume should remain in root (failed job stays for debugging)"
+    );
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn test_inputs_contract_still_works() {
+    require_docker();
+
+    let (success, _stdout, temp_path) = run_silva("inputs-contract");
+    assert!(success, "Workflow should succeed using inputs/ contract");
+
+    let temp = temp_path.expect("Should have temp folder path");
+
+    // Both jobs should be in @complete/
+    assert!(temp.join("@complete/01-produce").exists());
+    assert!(temp.join("@complete/02-consume").exists());
+
+    // Verify the report was actually generated with correct content
+    let report = std::fs::read_to_string(
+        temp.join("@complete/02-consume/outputs/report.txt"),
+    )
+    .expect("report.txt should exist");
+    assert!(report.contains("col1,col2"), "Report should contain CSV data");
+    assert!(report.contains("rows"), "Report should contain metadata");
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn test_three_node_chain_all_moved() {
+    require_docker();
+
+    let (success, _stdout, temp_path) = run_silva("three-node-chain");
+    assert!(success, "Three-node workflow should succeed");
+
+    let temp = temp_path.expect("Should have temp folder path");
+
+    // All three should be in @complete/
+    for node in &["01-produce", "02-consume", "03-final"] {
+        assert!(
+            !temp.join(node).exists(),
+            "{node} should not exist in root"
+        );
+        assert!(
+            temp.join(format!("@complete/{node}")).exists(),
+            "{node} should be in @complete/"
+        );
+    }
+
+    // Verify data flowed through the chain correctly
+    let final_output = std::fs::read_to_string(
+        temp.join("@complete/03-final/outputs/final.txt"),
+    )
+    .expect("final.txt should exist");
+    assert!(final_output.contains("step1"), "Should contain step1 data");
+    assert!(final_output.contains("step2"), "Should contain step2 data");
+    assert!(final_output.contains("done"), "Should contain final marker");
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn test_failed_job_not_moved() {
+    require_docker();
+
+    let (success, _stdout, temp_path) = run_silva("failed-job");
+    assert!(!success, "Workflow should fail because node 01 exits with error");
+
+    let temp = temp_path.expect("Should have temp folder path");
+
+    // Failed job should stay in root, not moved to @complete/
+    assert!(
+        temp.join("01-produce").exists(),
+        "Failed 01-produce should remain in root for debugging"
+    );
+    assert!(
+        !temp.join("@complete/01-produce").exists(),
+        "Failed 01-produce should NOT be in @complete/"
+    );
+
+    // 02-consume should never have run, so it stays in root too
+    assert!(
+        temp.join("02-consume").exists(),
+        "02-consume should remain in root (never ran)"
+    );
+    assert!(
+        !temp.join("@complete").exists(),
+        "@complete/ directory should not exist at all"
+    );
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp);
+}


### PR DESCRIPTION
## Summary
- After a node job completes, its folder is moved to `@complete/{job_name}/` in the temp workflow directory
- Dependency input copying updated to look in `@complete/` first, falling back to original location
- Prevents workflow authors from using cross-node relative paths (e.g., `../01-data-prep/`) — forces proper `inputs/` contract

Closes #71

## Test plan
- [x] 5 integration tests added (`silva/tests/integration_complete.rs`) covering:
  - Completed job moved to `@complete/`
  - Cross-node `../` path access fails after move
  - Proper `inputs/` contract still works
  - Three-node chain: all nodes end up in `@complete/`
  - Failed job stays in root (not moved)
- [x] All tests pass with `cargo test --test integration_complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)