### PR TITLE
feat(job_config): add registry = "local" to Container — opt-out of default_registry resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2]
+
+### Added
+
+- `job_config`: `registry = "local"` field in `[container]` — opt-out of default registry resolution (#80)
+  - Locally-built Docker images (e.g. `aso-rna:latest`) that do not exist in any remote registry can now be marked with `registry = "local"` to bypass the worker's `default_registry` prefix logic and skip `docker pull`
+  - Introduces `ImageSource::LocalImage` variant alongside existing `Registry`, `TarFile`, and `SifFile`
+
 ## [0.4.0]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["job_config", "silva"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT"
 authors = ["Qin Wan <qw@chiral.one>"]

--- a/job_config/src/job.rs
+++ b/job_config/src/job.rs
@@ -153,7 +153,10 @@ pub struct Container {
 impl Container {
     /// Creates a new container configuration with the given image.
     pub fn new(image: String) -> Self {
-        Self { image, registry: None }
+        Self {
+            image,
+            registry: None,
+        }
     }
 
     /// Returns the image source type based on the image string and registry hint.

--- a/job_config/src/job.rs
+++ b/job_config/src/job.rs
@@ -128,6 +128,9 @@ pub fn has_nvidia_gpu() -> bool {
 pub enum ImageSource {
     /// Pull image from a Docker registry (e.g., "ubuntu:22.04").
     Registry(String),
+    /// Use a locally-built Docker image — skip registry resolution entirely.
+    /// Set via `registry = "local"` in `[container]`.
+    LocalImage(String),
     /// Load image from a local tar file (e.g., "./image.tar").
     TarFile(String),
     /// Load image from a Singularity/Apptainer SIF file (e.g., "./image.sif").
@@ -141,20 +144,27 @@ pub struct Container {
     /// Docker image source: either a registry URL (e.g., "ubuntu:22.04")
     /// or a local file path (.tar for Docker, .sif for Singularity/Apptainer).
     pub image: String,
+    /// Optional registry hint. Set to `"local"` to bypass default_registry resolution
+    /// for images that are built locally and do not exist in any remote registry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registry: Option<String>,
 }
 
 impl Container {
     /// Creates a new container configuration with the given image.
     pub fn new(image: String) -> Self {
-        Self { image }
+        Self { image, registry: None }
     }
 
-    /// Returns the image source type based on the image string.
-    /// - Paths ending with ".tar" are treated as Docker tar archives.
-    /// - Paths ending with ".sif" are treated as Singularity/Apptainer images.
-    /// - Everything else is treated as a Docker registry URL.
+    /// Returns the image source type based on the image string and registry hint.
+    /// - `registry = "local"` → LocalImage (skip registry prefix resolution)
+    /// - Paths ending with ".tar" → TarFile
+    /// - Paths ending with ".sif" → SifFile
+    /// - Everything else → Registry
     pub fn get_image_source(&self) -> ImageSource {
-        if self.image.ends_with(".tar") {
+        if self.registry.as_deref() == Some("local") {
+            ImageSource::LocalImage(self.image.clone())
+        } else if self.image.ends_with(".tar") {
             ImageSource::TarFile(self.image.clone())
         } else if self.image.ends_with(".sif") {
             ImageSource::SifFile(self.image.clone())
@@ -507,6 +517,54 @@ mod tests {
         // Now returns JSON values
         assert_eq!(defaults.get("name").unwrap().as_str().unwrap(), "test");
         assert_eq!(defaults.get("count").unwrap().as_i64().unwrap(), 10);
+    }
+
+    #[test]
+    fn test_parse_container_with_registry_local() {
+        let toml_str = r#"
+            name = "ASO RNA Job"
+            description = "Local image job"
+
+            [container]
+            image = "aso-rna:latest"
+            registry = "local"
+        "#;
+
+        let meta: JobMeta = toml::from_str(toml_str).unwrap();
+        assert_eq!(meta.container.image, "aso-rna:latest");
+        assert_eq!(meta.container.registry, Some("local".to_string()));
+        assert_eq!(
+            meta.container.get_image_source(),
+            ImageSource::LocalImage("aso-rna:latest".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_container_without_registry_field() {
+        let toml_str = r#"
+            name = "Test Job"
+            description = "A test job"
+
+            [container]
+            image = "admet-pipeline:latest"
+        "#;
+
+        let meta: JobMeta = toml::from_str(toml_str).unwrap();
+        assert_eq!(meta.container.registry, None);
+        assert_eq!(
+            meta.container.get_image_source(),
+            ImageSource::Registry("admet-pipeline:latest".to_string())
+        );
+    }
+
+    #[test]
+    fn test_image_source_local_image() {
+        let mut container = Container::new("aso-rna:latest".to_string());
+        container.registry = Some("local".to_string());
+        assert_eq!(
+            container.get_image_source(),
+            ImageSource::LocalImage("aso-rna:latest".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `ImageSource::LocalImage(String)` variant to signal a locally-built Docker image that must not be resolved via any remote registry
- Add `registry: Option<String>` field to `Container` (TOML-optional, not serialized when absent)
- `get_image_source()` returns `LocalImage` when `registry = "local"` is set; falls through to existing `.tar` / `.sif` / registry detection otherwise

## Usage

```toml
[container]
image = "aso-rna:latest"
registry = "local"   # skip default_registry resolution
```

Closes #80

🤖 Generated with [Claude Code](https://claude.ai/claude-code)