### PR TITLE
fix: replace glob with globset to support brace expansion in inputs patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3]
+
+### Fixed
+
+- Brace expansion in `inputs` patterns now works correctly (#82)
+  - The `glob` crate silently returned zero matches for patterns like `*.{fasta,fa,faa}`; replaced with `globset` which supports brace expansion natively
+  - Affects both headless and TUI execution paths (`headless.rs` and `state.rs`)
+
 ## [0.5.2]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +192,16 @@ dependencies = [
  "serde",
  "serde_repr",
  "serde_with",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -761,10 +780,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "glob"
-version = "0.3.3"
+name = "globset"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "h2"
@@ -1244,7 +1270,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "job_config"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1761,6 +1787,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "silva"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arboard",
  "bollard",
@@ -2140,7 +2183,7 @@ dependencies = [
  "flume",
  "fs_extra",
  "futures-util",
- "glob",
+ "globset",
  "job_config",
  "open",
  "ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "job_config"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "silva"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["job_config", "silva"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT"
 authors = ["Qin Wan <qw@chiral.one>"]

--- a/silva/Cargo.toml
+++ b/silva/Cargo.toml
@@ -27,7 +27,7 @@ fs_extra = "1.3"
 sysinfo = "0.30"
 reqwest = { version = "0.12", features = ["json"] }
 semver = "1.0"
-glob = "0.3"
+globset = "0.4"
 open = "5.3"
 arboard = "3.4"
 

--- a/silva/src/components/docker/state.rs
+++ b/silva/src/components/docker/state.rs
@@ -674,6 +674,7 @@ async fn copy_input_files_from_dependencies(
     use std::collections::HashSet;
     use std::fs;
     use std::path::PathBuf;
+    use globset::GlobSetBuilder;
 
     if dependencies.is_empty() {
         return;
@@ -720,15 +721,10 @@ async fn copy_input_files_from_dependencies(
             }
         } else {
             // Copy only matching files based on input patterns
-            let mut matching_files = Vec::new();
+            let mut builder = GlobSetBuilder::new();
             for pattern in &config.inputs {
-                let glob_pattern = dep_outputs_dir.join(pattern).to_string_lossy().to_string();
-                match glob::glob(&glob_pattern) {
-                    Ok(paths) => {
-                        for path in paths.flatten() {
-                            matching_files.push(path);
-                        }
-                    }
+                match globset::Glob::new(pattern) {
+                    Ok(g) => { builder.add(g); }
                     Err(e) => {
                         let log_line = LogLine::new(
                             LogSource::Stderr,
@@ -738,7 +734,35 @@ async fn copy_input_files_from_dependencies(
                     }
                 }
             }
-            matching_files
+            match builder.build() {
+                Ok(matcher) => match fs::read_dir(&dep_outputs_dir) {
+                    Ok(entries) => entries
+                        .filter_map(|e| e.ok())
+                        .map(|e| e.path())
+                        .filter(|p| {
+                            p.file_name()
+                                .map(|n| matcher.is_match(n))
+                                .unwrap_or(false)
+                        })
+                        .collect(),
+                    Err(e) => {
+                        let log_line = LogLine::new(
+                            LogSource::Stderr,
+                            format!("Error reading outputs from '{dep_job_name}': {e}"),
+                        );
+                        let _ = tx.send((job_idx, JobStatus::Running, log_line)).await;
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    let log_line = LogLine::new(
+                        LogSource::Stderr,
+                        format!("Failed to build glob matcher for '{dep_job_name}': {e}"),
+                    );
+                    let _ = tx.send((job_idx, JobStatus::Running, log_line)).await;
+                    continue;
+                }
+            }
         };
 
         // Copy files to current job directory

--- a/silva/src/components/docker/state.rs
+++ b/silva/src/components/docker/state.rs
@@ -671,10 +671,10 @@ async fn copy_input_files_from_dependencies(
     tx: &mpsc::Sender<(usize, JobStatus, LogLine)>,
     job_idx: usize,
 ) {
+    use globset::GlobSetBuilder;
     use std::collections::HashSet;
     use std::fs;
     use std::path::PathBuf;
-    use globset::GlobSetBuilder;
 
     if dependencies.is_empty() {
         return;
@@ -724,7 +724,9 @@ async fn copy_input_files_from_dependencies(
             let mut builder = GlobSetBuilder::new();
             for pattern in &config.inputs {
                 match globset::Glob::new(pattern) {
-                    Ok(g) => { builder.add(g); }
+                    Ok(g) => {
+                        builder.add(g);
+                    }
                     Err(e) => {
                         let log_line = LogLine::new(
                             LogSource::Stderr,
@@ -739,11 +741,7 @@ async fn copy_input_files_from_dependencies(
                     Ok(entries) => entries
                         .filter_map(|e| e.ok())
                         .map(|e| e.path())
-                        .filter(|p| {
-                            p.file_name()
-                                .map(|n| matcher.is_match(n))
-                                .unwrap_or(false)
-                        })
+                        .filter(|p| p.file_name().map(|n| matcher.is_match(n)).unwrap_or(false))
                         .collect(),
                     Err(e) => {
                         let log_line = LogLine::new(

--- a/silva/src/headless.rs
+++ b/silva/src/headless.rs
@@ -477,7 +477,9 @@ fn copy_input_files_from_dependencies(
             let mut builder = GlobSetBuilder::new();
             for pattern in &config.inputs {
                 match globset::Glob::new(pattern) {
-                    Ok(g) => { builder.add(g); }
+                    Ok(g) => {
+                        builder.add(g);
+                    }
                     Err(e) => println!("Invalid glob pattern '{pattern}': {e}"),
                 }
             }
@@ -486,11 +488,7 @@ fn copy_input_files_from_dependencies(
                     Ok(entries) => entries
                         .filter_map(|e| e.ok())
                         .map(|e| e.path())
-                        .filter(|p| {
-                            p.file_name()
-                                .map(|n| matcher.is_match(n))
-                                .unwrap_or(false)
-                        })
+                        .filter(|p| p.file_name().map(|n| matcher.is_match(n)).unwrap_or(false))
                         .collect(),
                     Err(e) => {
                         println!("Error reading outputs from '{dep_job_name}': {e}");
@@ -716,16 +714,30 @@ mod tests {
     fn brace_pattern_copies_matching_extensions() {
         let tmp = tempfile::tempdir().unwrap();
         let wf = tmp.path();
-        setup_dep_outputs(wf, "01-produce", &["seq.fasta", "ref.fa", "proteins.faa", "notes.txt"]);
+        setup_dep_outputs(
+            wf,
+            "01-produce",
+            &["seq.fasta", "ref.fa", "proteins.faa", "notes.txt"],
+        );
 
         let producer = JobFolder::new("01-produce".to_string(), wf.join("01-produce"));
         let consumer = JobFolder::new("02-consume".to_string(), wf.join("02-consume"));
         let config = make_job_meta(vec!["*.{fasta,fa,faa}"]);
 
-        let n = copy_input_files_from_dependencies(wf, &consumer, &[producer], &config, &["01-produce".to_string()]).unwrap();
+        let n = copy_input_files_from_dependencies(
+            wf,
+            &consumer,
+            &[producer],
+            &config,
+            &["01-produce".to_string()],
+        )
+        .unwrap();
 
         assert_eq!(n, 3);
-        assert_eq!(list_inputs(wf, "02-consume"), vec!["proteins.faa", "ref.fa", "seq.fasta"]);
+        assert_eq!(
+            list_inputs(wf, "02-consume"),
+            vec!["proteins.faa", "ref.fa", "seq.fasta"]
+        );
     }
 
     #[test]
@@ -738,7 +750,14 @@ mod tests {
         let consumer = JobFolder::new("02-consume".to_string(), wf.join("02-consume"));
         let config = make_job_meta(vec!["*.{fasta,fa,faa}"]);
 
-        let n = copy_input_files_from_dependencies(wf, &consumer, &[producer], &config, &["01-produce".to_string()]).unwrap();
+        let n = copy_input_files_from_dependencies(
+            wf,
+            &consumer,
+            &[producer],
+            &config,
+            &["01-produce".to_string()],
+        )
+        .unwrap();
 
         assert_eq!(n, 1);
         assert_eq!(list_inputs(wf, "02-consume"), vec!["c.fasta"]);
@@ -748,16 +767,30 @@ mod tests {
     fn plain_pattern_still_works() {
         let tmp = tempfile::tempdir().unwrap();
         let wf = tmp.path();
-        setup_dep_outputs(wf, "01-produce", &["data.csv", "metadata.json", "other.txt"]);
+        setup_dep_outputs(
+            wf,
+            "01-produce",
+            &["data.csv", "metadata.json", "other.txt"],
+        );
 
         let producer = JobFolder::new("01-produce".to_string(), wf.join("01-produce"));
         let consumer = JobFolder::new("02-consume".to_string(), wf.join("02-consume"));
         let config = make_job_meta(vec!["*.csv", "*.json"]);
 
-        let n = copy_input_files_from_dependencies(wf, &consumer, &[producer], &config, &["01-produce".to_string()]).unwrap();
+        let n = copy_input_files_from_dependencies(
+            wf,
+            &consumer,
+            &[producer],
+            &config,
+            &["01-produce".to_string()],
+        )
+        .unwrap();
 
         assert_eq!(n, 2);
-        assert_eq!(list_inputs(wf, "02-consume"), vec!["data.csv", "metadata.json"]);
+        assert_eq!(
+            list_inputs(wf, "02-consume"),
+            vec!["data.csv", "metadata.json"]
+        );
     }
 
     #[test]
@@ -770,9 +803,19 @@ mod tests {
         let consumer = JobFolder::new("02-consume".to_string(), wf.join("02-consume"));
         let config = make_job_meta(vec![]);
 
-        let n = copy_input_files_from_dependencies(wf, &consumer, &[producer], &config, &["01-produce".to_string()]).unwrap();
+        let n = copy_input_files_from_dependencies(
+            wf,
+            &consumer,
+            &[producer],
+            &config,
+            &["01-produce".to_string()],
+        )
+        .unwrap();
 
         assert_eq!(n, 3);
-        assert_eq!(list_inputs(wf, "02-consume"), vec!["a.txt", "b.csv", "c.fasta"]);
+        assert_eq!(
+            list_inputs(wf, "02-consume"),
+            vec!["a.txt", "b.csv", "c.fasta"]
+        );
     }
 }

--- a/silva/src/headless.rs
+++ b/silva/src/headless.rs
@@ -669,3 +669,110 @@ fn copy_input_files_to_dependency_free_jobs(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use job_config::job::{Container, JobMeta, Scripts};
+    use std::collections::HashMap;
+    use std::fs;
+
+    fn make_job_meta(inputs: Vec<&str>) -> JobMeta {
+        JobMeta {
+            name: "test".to_string(),
+            description: String::new(),
+            container: Container::new("ubuntu:latest".to_string()),
+            scripts: Scripts {
+                pre: String::new(),
+                run: "run.sh".to_string(),
+                post: String::new(),
+            },
+            inputs: inputs.into_iter().map(String::from).collect(),
+            outputs: vec![],
+            params: HashMap::new(),
+        }
+    }
+
+    fn setup_dep_outputs(workflow: &Path, dep_name: &str, files: &[&str]) {
+        let outputs_dir = workflow.join(dep_name).join("outputs");
+        fs::create_dir_all(&outputs_dir).unwrap();
+        for f in files {
+            fs::write(outputs_dir.join(f), f).unwrap();
+        }
+    }
+
+    fn list_inputs(workflow: &Path, job_name: &str) -> Vec<String> {
+        let inputs_dir = workflow.join(job_name).join("inputs");
+        let mut names: Vec<String> = fs::read_dir(inputs_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn brace_pattern_copies_matching_extensions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wf = tmp.path();
+        setup_dep_outputs(wf, "01-produce", &["seq.fasta", "ref.fa", "proteins.faa", "notes.txt"]);
+
+        let producer = JobFolder::new("01-produce".to_string(), wf.join("01-produce"));
+        let consumer = JobFolder::new("02-consume".to_string(), wf.join("02-consume"));
+        let config = make_job_meta(vec!["*.{fasta,fa,faa}"]);
+
+        let n = copy_input_files_from_dependencies(wf, &consumer, &[producer], &config, &["01-produce".to_string()]).unwrap();
+
+        assert_eq!(n, 3);
+        assert_eq!(list_inputs(wf, "02-consume"), vec!["proteins.faa", "ref.fa", "seq.fasta"]);
+    }
+
+    #[test]
+    fn brace_pattern_excludes_non_matching_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wf = tmp.path();
+        setup_dep_outputs(wf, "01-produce", &["a.txt", "b.log", "c.fasta"]);
+
+        let producer = JobFolder::new("01-produce".to_string(), wf.join("01-produce"));
+        let consumer = JobFolder::new("02-consume".to_string(), wf.join("02-consume"));
+        let config = make_job_meta(vec!["*.{fasta,fa,faa}"]);
+
+        let n = copy_input_files_from_dependencies(wf, &consumer, &[producer], &config, &["01-produce".to_string()]).unwrap();
+
+        assert_eq!(n, 1);
+        assert_eq!(list_inputs(wf, "02-consume"), vec!["c.fasta"]);
+    }
+
+    #[test]
+    fn plain_pattern_still_works() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wf = tmp.path();
+        setup_dep_outputs(wf, "01-produce", &["data.csv", "metadata.json", "other.txt"]);
+
+        let producer = JobFolder::new("01-produce".to_string(), wf.join("01-produce"));
+        let consumer = JobFolder::new("02-consume".to_string(), wf.join("02-consume"));
+        let config = make_job_meta(vec!["*.csv", "*.json"]);
+
+        let n = copy_input_files_from_dependencies(wf, &consumer, &[producer], &config, &["01-produce".to_string()]).unwrap();
+
+        assert_eq!(n, 2);
+        assert_eq!(list_inputs(wf, "02-consume"), vec!["data.csv", "metadata.json"]);
+    }
+
+    #[test]
+    fn empty_inputs_copies_all_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wf = tmp.path();
+        setup_dep_outputs(wf, "01-produce", &["a.txt", "b.csv", "c.fasta"]);
+
+        let producer = JobFolder::new("01-produce".to_string(), wf.join("01-produce"));
+        let consumer = JobFolder::new("02-consume".to_string(), wf.join("02-consume"));
+        let config = make_job_meta(vec![]);
+
+        let n = copy_input_files_from_dependencies(wf, &consumer, &[producer], &config, &["01-produce".to_string()]).unwrap();
+
+        assert_eq!(n, 3);
+        assert_eq!(list_inputs(wf, "02-consume"), vec!["a.txt", "b.csv", "c.fasta"]);
+    }
+}

--- a/silva/src/headless.rs
+++ b/silva/src/headless.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::SystemTime;
 
+use globset::GlobSetBuilder;
+
 use tempfile::TempDir;
 use tokio::sync::mpsc;
 
@@ -472,21 +474,34 @@ fn copy_input_files_from_dependencies(
             }
         } else {
             // Copy only matching files based on input patterns
-            let mut matching_files = Vec::new();
+            let mut builder = GlobSetBuilder::new();
             for pattern in &config.inputs {
-                let glob_pattern = dep_outputs_dir.join(pattern).to_string_lossy().to_string();
-                match glob::glob(&glob_pattern) {
-                    Ok(paths) => {
-                        for path in paths.flatten() {
-                            matching_files.push(path);
-                        }
-                    }
-                    Err(e) => {
-                        println!("Invalid glob pattern '{pattern}': {e}");
-                    }
+                match globset::Glob::new(pattern) {
+                    Ok(g) => { builder.add(g); }
+                    Err(e) => println!("Invalid glob pattern '{pattern}': {e}"),
                 }
             }
-            matching_files
+            match builder.build() {
+                Ok(matcher) => match fs::read_dir(&dep_outputs_dir) {
+                    Ok(entries) => entries
+                        .filter_map(|e| e.ok())
+                        .map(|e| e.path())
+                        .filter(|p| {
+                            p.file_name()
+                                .map(|n| matcher.is_match(n))
+                                .unwrap_or(false)
+                        })
+                        .collect(),
+                    Err(e) => {
+                        println!("Error reading outputs from '{dep_job_name}': {e}");
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    println!("Failed to build glob matcher for '{dep_job_name}': {e}");
+                    continue;
+                }
+            }
         };
 
         // Copy files to inputs/ directory

--- a/silva/tests/fixtures/workflow-complete/brace-glob/.chiral/workflow.toml
+++ b/silva/tests/fixtures/workflow-complete/brace-glob/.chiral/workflow.toml
@@ -1,0 +1,5 @@
+name = "brace-glob"
+description = "Test that brace expansion in inputs patterns works"
+
+[dependencies]
+02-consume = ["01-produce"]

--- a/silva/tests/fixtures/workflow-complete/brace-glob/01-produce/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/brace-glob/01-produce/.chiral/job.toml
@@ -1,0 +1,9 @@
+name = "Produce"
+description = "Produces sequence files and an unrelated text file"
+outputs = ["seq.fasta", "ref.fa", "proteins.faa", "notes.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/brace-glob/01-produce/run.sh
+++ b/silva/tests/fixtures/workflow-complete/brace-glob/01-produce/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+echo ">seq1" > seq.fasta
+echo "ACGT" >> seq.fasta
+echo ">ref1" > ref.fa
+echo "TTGG" >> ref.fa
+echo ">prot1" > proteins.faa
+echo "MKVL" >> proteins.faa
+echo "this should not be copied" > notes.txt

--- a/silva/tests/fixtures/workflow-complete/brace-glob/02-consume/.chiral/job.toml
+++ b/silva/tests/fixtures/workflow-complete/brace-glob/02-consume/.chiral/job.toml
@@ -1,0 +1,10 @@
+name = "Consume"
+description = "Reads only sequence files via brace expansion pattern"
+inputs = ["*.{fasta,fa,faa}"]
+outputs = ["result.txt"]
+
+[container]
+image = "ubuntu:latest"
+
+[scripts]
+run = "run.sh"

--- a/silva/tests/fixtures/workflow-complete/brace-glob/02-consume/run.sh
+++ b/silva/tests/fixtures/workflow-complete/brace-glob/02-consume/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+count=$(ls inputs/ | wc -l | tr -d ' ')
+echo "sequence_files=$count" > result.txt
+ls inputs/ >> result.txt
+# Fail if notes.txt leaked into inputs/
+if [ -f inputs/notes.txt ]; then
+    echo "ERROR: notes.txt should not have been copied" >&2
+    exit 1
+fi

--- a/silva/tests/integration_complete.rs
+++ b/silva/tests/integration_complete.rs
@@ -225,3 +225,30 @@ fn test_failed_job_not_moved() {
     // Cleanup
     let _ = std::fs::remove_dir_all(&temp);
 }
+
+#[test]
+fn test_brace_glob_pattern_copies_only_matching_files() {
+    require_docker();
+
+    let (success, _stdout, temp_path) = run_silva("brace-glob");
+    assert!(success, "Workflow should succeed with brace expansion pattern");
+
+    let temp = temp_path.expect("Should have temp folder path");
+
+    let result = std::fs::read_to_string(
+        temp.join("@complete/02-consume/outputs/result.txt"),
+    )
+    .expect("result.txt should exist");
+
+    assert!(
+        result.contains("sequence_files=3"),
+        "Exactly 3 sequence files should be copied into inputs/. Output:\n{result}"
+    );
+    assert!(result.contains("seq.fasta"), "seq.fasta should be in inputs/");
+    assert!(result.contains("ref.fa"), "ref.fa should be in inputs/");
+    assert!(result.contains("proteins.faa"), "proteins.faa should be in inputs/");
+    assert!(!result.contains("notes.txt"), "notes.txt must not be in inputs/");
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp);
+}

--- a/silva/tests/integration_complete.rs
+++ b/silva/tests/integration_complete.rs
@@ -231,23 +231,33 @@ fn test_brace_glob_pattern_copies_only_matching_files() {
     require_docker();
 
     let (success, _stdout, temp_path) = run_silva("brace-glob");
-    assert!(success, "Workflow should succeed with brace expansion pattern");
+    assert!(
+        success,
+        "Workflow should succeed with brace expansion pattern"
+    );
 
     let temp = temp_path.expect("Should have temp folder path");
 
-    let result = std::fs::read_to_string(
-        temp.join("@complete/02-consume/outputs/result.txt"),
-    )
-    .expect("result.txt should exist");
+    let result = std::fs::read_to_string(temp.join("@complete/02-consume/outputs/result.txt"))
+        .expect("result.txt should exist");
 
     assert!(
         result.contains("sequence_files=3"),
         "Exactly 3 sequence files should be copied into inputs/. Output:\n{result}"
     );
-    assert!(result.contains("seq.fasta"), "seq.fasta should be in inputs/");
+    assert!(
+        result.contains("seq.fasta"),
+        "seq.fasta should be in inputs/"
+    );
     assert!(result.contains("ref.fa"), "ref.fa should be in inputs/");
-    assert!(result.contains("proteins.faa"), "proteins.faa should be in inputs/");
-    assert!(!result.contains("notes.txt"), "notes.txt must not be in inputs/");
+    assert!(
+        result.contains("proteins.faa"),
+        "proteins.faa should be in inputs/"
+    );
+    assert!(
+        !result.contains("notes.txt"),
+        "notes.txt must not be in inputs/"
+    );
 
     // Cleanup
     let _ = std::fs::remove_dir_all(&temp);


### PR DESCRIPTION
Fixes #82

## Summary

- `glob` crate silently returns zero matches for patterns like `*.{fasta,fa,faa}` — no warning, downstream job starts with empty `inputs/` and fails
- Replace `glob = "0.3"` with `globset = "0.4"` which supports brace expansion natively
- Both execution paths updated: `headless.rs` (headless mode) and `state.rs` (TUI mode)
- Pattern matching now uses `GlobSetBuilder` + `fs::read_dir` + filename matcher, replacing the previous `glob::glob(path_string)` approach

## Tests

- 4 unit tests in `headless::tests` (no Docker): brace pattern matches multiple extensions, non-matching files excluded, plain patterns still work, empty inputs copies all
- Integration fixture `brace-glob`: `01-produce` outputs `.fasta`/`.fa`/`.faa`/`.txt`; `02-consume` uses `inputs = ["*.{fasta,fa,faa}"]` and asserts exactly 3 sequence files in `inputs/`, fails if `notes.txt` leaks through

## Verified against collab-workflows

- workflow-014 — passed
- workflow-015 — passed (`*.{fasta,fa,faa}` brace pattern exercised end-to-end)
- workflow-017 — pre-existing script bug (reads from working dir instead of `inputs/`), unrelated to this change